### PR TITLE
fix: typos in readme and code

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,3 +20,5 @@ jobs:
       with:
         python-version: "3.9"
     - uses: pre-commit/action@v3.0.1
+      env:
+        SKIP: pixi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,10 @@ repos:
     rev: v3.0.2
     hooks:
       - id: reuse
+  - repo: local
+    hooks:
+      - id: pixi
+        name: check outdated pixi.lock
+        language: system
+        entry: pixi list --locked
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 [![coverage](https://raw.githubusercontent.com/idiap/gridtk/python-coverage-comment-action-data/badge.svg)](https://htmlpreview.github.io/?https://github.com/idiap/gridtk/blob/python-coverage-comment-action-data/htmlcov/index.html)
 [![repository](https://img.shields.io/badge/github-project-0000c0.svg)](https://github.com/idiap/gridtk)
 
-# GridTK: Slurm Job Managetment for Humans
+# GridTK: Slurm Job Management for Humans
 
 ## Introduction
 
@@ -36,9 +36,9 @@ To install GridTK, open your terminal and run the following command:
 ```bash
 $ pipx install gridtk
 ```
-It is **not recommennded** to install GridTK using `pip install gridtk` in the
-same environment as your expeirments. GirdTK does not need to be installed in
-the same environment as your experiments and its depencencies may conflict with
+It is **not recommended** to install GridTK using `pip install gridtk` in the
+same environment as your experiments. GirdTK does not need to be installed in
+the same environment as your experiments and its dependencies may conflict with
 your experiments' dependencies.
 
 ## Basic Usage
@@ -70,8 +70,8 @@ numbers always start with 1 which is easier to remember than the slurm job id.
 Run `gridtk submit --help` to see the list of `gridtk submit` specific options and run `sbatch --help` to see the full list of options for `sbatch`.
 
 Note that your slurm cluster may require you to specify a partition, an account,
-or anoher option. You can do so by adding them to `gridtk submit --accoount=myaccount --partition=mypartition job.sh`
-or setting default values using enviroment variables such as
+or another option. You can do so by adding them to `gridtk submit --account=myaccount --partition=mypartition job.sh`
+or setting default values using environment variables such as
 `SBATCH_ACCOUNT` and `SBATCH_PARTITION`.
 
 ### Monitoring Jobs
@@ -114,10 +114,10 @@ To stop a running or pending job, use the `gridtk stop` command:
 
 ```bash
 $ gridtk stop -j 1
-Stopped job 1 wiht slurm id 136132
+Stopped job 1 with slurm id 136132
 ```
 
-Stopped jobs will be still avaliable in the job list:
+Stopped jobs will be still available in the job list:
 ```bash
 $ gridtk list
   job-id    slurm-id  nodes    state          job-name    output                  dependencies    command
@@ -160,7 +160,8 @@ GridTK provides several advanced commands to help with more complex job
 management tasks. These include job dependencies, array jobs, and resource
 management.
 
-### Job Submission wihtout a Script
+### Job Submission without a Script
+
 Since GridTK keeps track of both the sbatch options and the command to run, you
 can skip creating a script and submit a job directly from the command line.
 This is done by using `---` (3 dashes) to separate the sbatch options from the command to
@@ -169,7 +170,7 @@ run:
 $ gridtk submit --job-name=gridtk-no-script --- echo 'Hello, GridTK!'
 2
 ```
-This syntax is unique to `girdtk submit` and is not supported by `sbatch`.
+This syntax is unique to `gridtk submit` and is not supported by `sbatch`.
 ```bash
 $ gridtk list
   job-id    slurm-id  nodes    state        job-name          output                            dependencies    command
@@ -193,9 +194,9 @@ echo 'Hello, GridTK!'
 
 Output file: logs/gridtk-no-script.136142.out
 ```
-This is a fast, convenient, and **recomended** way to submit a job without having to create a
-script and since everthing is tracked by GridTK, you still benefit from the same
-reproducibility gurantees.
+This is a fast, convenient, and **recommended** way to submit a job without having to create a
+script and since everything is tracked by GridTK, you still benefit from the same
+reproducibility guarantees.
 
 ### Job Dependencies
 
@@ -214,15 +215,15 @@ You can submit the same script N times using the `--repeat` flag:
 $ gridtk submit --repeat=3 job.sh
 ```
 This will submit 3 jobs with the same script and the same options where each job
-will depeend on the previous one. This is useful if your script can resume from
+will depend on the previous one. This is useful if your script can resume from
 a checkpoint and you want to run it effectively for a longer time than allowed
-by polciy.
+by policy.
 
 ### Monitoring Jobs
 
 While `gridtk list` and `gridtk report` are useful for checking the status of jobs,
 you might get more information about your jobs using `squeue`, `scontrol`, and `sacct`.
-Here are some usefull commands:
+Here are some useful commands:
 
 * Get information about a specific job: `scontrol show job <slurm_job_id>`
 * Get information about a completed or failed job: `sacct -j <slurm_job_id>`.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ installation, submission, monitoring, and various commands provided by GridTK.
 Before diving into GridTK, ensure you have the following prerequisites:
 
 1. A working Slurm setup.
-2. [pipx](https://pipx.pypa.io/stable/) installed.
+2. [Pixi](https://pixi.sh/) (recommended) or [pipx](https://pipx.pypa.io/stable/) installed.
 3. GridTK installed (instructions provided below).
 
 ## Installation
@@ -34,6 +34,11 @@ Before diving into GridTK, ensure you have the following prerequisites:
 To install GridTK, open your terminal and run the following command:
 
 ```bash
+# Install gridtk using pixi
+$ curl -fsSL https://pixi.sh/install.sh | bash # installs pixi
+$ pixi global install gridtk
+
+# Install gridtk using pipx
 $ pipx install gridtk
 ```
 It is **not recommended** to install GridTK using `pip install gridtk` in the
@@ -142,7 +147,7 @@ $ gridtk submit job.sh
 1
 
 $ gridtk stop -j 1
-Stopped job 1 wiht slurm id 136139
+Stopped job 1 with slurm id 136139
 
 $ gridtk resubmit -j 1
 Resubmitted job 1

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To install GridTK, open your terminal and run the following command:
 $ pipx install gridtk
 ```
 It is **not recommended** to install GridTK using `pip install gridtk` in the
-same environment as your experiments. GirdTK does not need to be installed in
+same environment as your experiments. GridTK does not need to be installed in
 the same environment as your experiments and its dependencies may conflict with
 your experiments' dependencies.
 
@@ -63,7 +63,7 @@ Submit the job using `gridtk submit`:
 $ gridtk submit job.sh
 1
 ```
-where `1` is the the local job id (not the slurm job id) for your job. The job
+where `1` is the local job id (not the slurm job id) for your job. The job
 numbers always start with 1 which is easier to remember than the slurm job id.
 
 `gridtk submit` is a drop-in replacement for `sbatch` and accepts the same options while adding its own.

--- a/pixi.lock
+++ b/pixi.lock
@@ -375,9 +375,9 @@ packages:
   requires_python: '>=3.7'
 - kind: pypi
   name: gridtk
-  version: 2.1.1.dev35+g97ecde7
+  version: 3.0.1.dev4+ge1d63ef
   path: .
-  sha256: c6c00e75434bfb7f19b891646b561340b966ce96112c3e9948071376b89f4141
+  sha256: 098b931aa522fe8a839ee2b94a621e244b55c28f03fc0d230afa1ed2f6ae175d
   requires_dist:
   - click~=8.1
   - sqlalchemy~=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 name = "gridtk"
 dynamic = ["version"]
 requires-python = ">=3.9"
-description = "GridTK: Slurm Job Managetment for Humans"
+description = "GridTK: Slurm Job Management for Humans"
 readme = "README.md"
 license = "GPL-3.0-or-later"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = ["sqlalchemy~=2.0", "tabulate~=0.9.0", "click~=8.1"]
 
 [project.urls]
-documentation = "https://gridtk.readthedocs.io/en/latest/"
+documentation = "https://gridtk.readthedocs.io/en/stable/"
 homepage = "https://pypi.org/project/gridtk"
 repository = "https://github.com/idiap/gridtk"
 changelog = "https://github.com/idiap/gridtk/releases"

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -354,7 +354,7 @@ def job_filters(f_py=None, default_states=None):
         function = click.option(
             "--dependents/--no-dependents",
             default=False,
-            help="Select dependents jobs (jobs that depend on seleted jobs) as well.",
+            help="Select dependents jobs (jobs that depend on selected jobs) as well.",
         )(function)
         return function  # noqa: RET504
 
@@ -403,7 +403,7 @@ def stop(
             job_ids=job_ids, states=states, names=names, dependents=dependents
         )
         for job in jobs:
-            click.echo(f"Stopped job {job.id} wiht slurm id {job.grid_id}")
+            click.echo(f"Stopped job {job.id} with slurm id {job.grid_id}")
         session.commit()
 
 

--- a/src/gridtk/models.py
+++ b/src/gridtk/models.py
@@ -71,7 +71,7 @@ JOB_STATES_MAPPING = {
 """Some of these states are only shown when using scontrol or squeue but these
 commands do not provide info for finished commands.
 
-sacct only retuns these states https://slurm.schedmd.com/sacct.html#lbAG
+sacct only returns these states https://slurm.schedmd.com/sacct.html#lbAG
 """
 
 

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -281,7 +281,7 @@ def test_stop_jobs(mock_check_output, runner):
         mock_check_output.return_value = _pending_job_sacct_json(submit_job_id)
         result = runner.invoke(cli, ["stop", "--name", "gridtk"])
         assert_click_runner_result(result)
-        assert result.output == f"Stopped job 1 wiht slurm id {submit_job_id}\n"
+        assert result.output == f"Stopped job 1 with slurm id {submit_job_id}\n"
         mock_check_output.assert_called_with(["scancel", str(submit_job_id)])
 
 


### PR DESCRIPTION
Fixed a few typos in the readme, and in the code.

<!-- readthedocs-preview gridtk start -->
----
📚 Documentation preview 📚: https://gridtk--5.org.readthedocs.build/en/5/

<!-- readthedocs-preview gridtk end -->