### PR TITLE
fix: managing slurms without accounting and a few bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ installation, submission, monitoring, and various commands provided by GridTK.
 Before diving into GridTK, ensure you have the following prerequisites:
 
 1. A working Slurm setup.
-2. [Pixi](https://pixi.sh/) (recommended) or [pipx](https://pipx.pypa.io/stable/) installed.
+2. [pipx](https://pipx.pypa.io/stable/) installed.
 3. GridTK installed (instructions provided below).
 
 ## Installation
@@ -34,11 +34,6 @@ Before diving into GridTK, ensure you have the following prerequisites:
 To install GridTK, open your terminal and run the following command:
 
 ```bash
-# Install gridtk using pixi
-$ curl -fsSL https://pixi.sh/install.sh | bash # installs pixi
-$ pixi global install gridtk
-
-# Install gridtk using pipx
 $ pipx install gridtk
 ```
 It is **not recommended** to install GridTK using `pip install gridtk` in the

--- a/src/gridtk/manager.py
+++ b/src/gridtk/manager.py
@@ -38,10 +38,13 @@ from .tools import job_ids_from_dep_str, parse_array_indexes
 def update_job_statuses(grid_ids: Iterable[int]) -> dict[int, dict]:
     """Retrieve the status of the jobs in the database."""
     status = dict()
-    output = subprocess.check_output(
-        ["sacct", "-j", ",".join([str(x) for x in grid_ids]), "--json"],
-        text=True,
-    )
+    try:
+        output = subprocess.check_output(
+            ["sacct", "-j", ",".join([str(x) for x in grid_ids]), "--json"],
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return status
     for job in json.loads(output)["jobs"]:
         status[job["job_id"]] = job
     return status

--- a/src/gridtk/manager.py
+++ b/src/gridtk/manager.py
@@ -203,6 +203,6 @@ dependencies: {dependencies}"""
                 and len(self.list_jobs(update_jobs=False)) == 0
             ):
                 Path(self.database).unlink()
-            if self.logs_dir.exists() and len(os.listdir(self.logs_dir)) == 0:
-                shutil.rmtree(self.logs_dir)
+                if self.logs_dir.exists() and len(os.listdir(self.logs_dir)) == 0:
+                    shutil.rmtree(self.logs_dir)
         self.engine.dispose()


### PR DESCRIPTION
fix: handle sacct failures
fix: retrieve job status from scontrol when sacct is not available
fix: do not delete the logs folder when the database is not empty
fix: do not recommend installing with pixi

<!-- readthedocs-preview gridtk start -->
----
📚 Documentation preview 📚: https://gridtk--6.org.readthedocs.build/en/6/

<!-- readthedocs-preview gridtk end -->