### PR TITLE
Add state filter tests and handle readonly database

### DIFF
--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -76,7 +76,9 @@ def parse_states(states: str) -> list[str]:
     for state in states.split(","):
         state = JOB_STATES_MAPPING.get(state, state)
         if state not in JOB_STATES_MAPPING.values():
-            raise click.BadParameter(f"Invalid state: {state}")
+            raise click.BadParameter(
+                f"Invalid state: {state}\nValid values are: ALL {' '.join(list(JOB_STATES_MAPPING.keys())+list(JOB_STATES_MAPPING.values()))} or a comma (,) separated list of them."
+            )
         final_states.append(state)
     return final_states
 
@@ -410,12 +412,13 @@ def list_jobs(
             table["nodes"].append(job.nodes)
             table["state"].append(f"{job.state} ({job.exit_code})")
             table["job-name"].append(job.name)
-            table["output"].append(
-                job_manager.logs_dir
-                / job.output_files[0]
-                .resolve()
-                .relative_to(job_manager.logs_dir.resolve())
-            )
+            output = job_manager.logs_dir / job.output_files[0].resolve()
+            try:
+                output = output.relative_to(job_manager.logs_dir.resolve())
+            except ValueError:
+                pass
+
+            table["output"].append(output)
             table["dependencies"].append(
                 ",".join([str(dep_job) for dep_job in job.dependencies_ids])
             )

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -142,14 +142,14 @@ def job_filters(f_py=None, default_states=None):
     "--database",
     help="Path to the database file.",
     default=Path("jobs.sql3"),
-    type=click.Path(path_type=Path, file_okay=True, dir_okay=False, writable=True),
+    type=click.Path(path_type=Path, file_okay=True, dir_okay=False),
 )
 @click.option(
     "-l",
     "--logs-dir",
     help="Path to the logs directory.",
     default=Path("logs"),
-    type=click.Path(path_type=Path, file_okay=False, dir_okay=True, writable=True),
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
 )
 @click.pass_context
 def cli(ctx, database, logs_dir):

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -119,7 +119,12 @@ def job_filters(f_py=None, default_states=None):
             "-j",
             "--jobs",
             "job_ids",
-            help="Selects only these job ids, separated by comma.",  # TODO: explain range notation
+            help=(
+                "Selects only these job ids, separated by comma. A range can also be "
+                "specified in the form 'start-end' ('-j 3-5' is equivalent to "
+                "'-j 3,4,5') or in the form 'start+length' ('-j 4+3' is equivalent to "
+                "'-j 4,5,6,7')."
+            ),
             callback=job_ids_callback,
         )(function)
         function = click.option(

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -412,9 +412,9 @@ def list_jobs(
             table["nodes"].append(job.nodes)
             table["state"].append(f"{job.state} ({job.exit_code})")
             table["job-name"].append(job.name)
-            output = job_manager.logs_dir / job.output_files[0].resolve()
+            output = job.output_files[0].resolve()
             try:
-                output = output.relative_to(job_manager.logs_dir.resolve())
+                output = output.relative_to(Path.cwd().resolve())
             except ValueError:
                 pass
 


### PR DESCRIPTION
fix: more error handling
    
    Handle cases when job_manager.logs_dir is not relative to logs.
    Also output valid states when state callback fails.

fix: when the database is read-only
    
    It can happen that the database could be read-only but running commands like gridtk list should still work.

test: add tests for state-based filtering
    
    Adding some tests to make sure state-based filtering of jobs works

<!-- readthedocs-preview gridtk start -->
----
📚 Documentation preview 📚: https://gridtk--8.org.readthedocs.build/en/8/

<!-- readthedocs-preview gridtk end -->