### PR TITLE
ci: fix the 'deploy' workflow for dists on github.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Retrieve the package from GitHub actions artifacts
         uses: actions/download-artifact@v4
         with:
-          name: release-dist
+          name: release-dists
           path: dist/
       - name: Upload the release package to GitHub Release
         env:


### PR DESCRIPTION
The name of the artifact expected by `github-publish` was not the same as the one created in `release-build`.
Fixed the artifact name to correspond to [publishing to PyPI](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-pypi).

<!-- readthedocs-preview gridtk start -->
----
📚 Documentation preview 📚: https://gridtk--10.org.readthedocs.build/en/10/

<!-- readthedocs-preview gridtk end -->