### PR TITLE
CI: Fix the coverage reports artifacts not being uploaded

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,8 @@ jobs:
         with:
           name: coverage-${{ matrix.pixi_environment }}
           path: .coverage.${{ matrix.pixi_environment }}
+          include-hidden-files: true
+          if-no-files-found: error
 
   merge-coverage:
     name: Merge the coverage reports from multiple coverages


### PR DESCRIPTION
The upload-artifacts action won't upload hidden files by default anymore.
This forces the inclusion of hidden files as it is required by merge-coverage and triggers an error when no coverage report file is found.

[related issue on coverage-comment-action](https://github.com/py-cov-action/python-coverage-comment-action/issues/473)

<!-- readthedocs-preview gridtk start -->
----
📚 Documentation preview 📚: https://gridtk--11.org.readthedocs.build/en/11/

<!-- readthedocs-preview gridtk end -->