### PR TITLE
feat: adjust gridtk list output to fit terminal width

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,7 +1,0 @@
-{
-  "tasks": {
-    "test": "pixi run test",
-    "build": "pixi install",
-    "launch": "pixi run gridtk"
-  }
-}

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "tasks": {
+    "test": "pixi run test",
+    "build": "pixi install",
+    "launch": "pixi run gridtk"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -254,25 +254,26 @@ eval "$(_GRIDTK_COMPLETE=zsh_source gridtk)"
 
 ### Adjusting `gridtk list` Output
 
-By default, the `gridtk list` output adjusts to fit the terminal width, with wraping. There are two options: `--truncate` and `--full-output`.
-The `--truncate` option truncates the output to fit the terminal width, while the `--full-output` option displays the full output without wrapping.
+By default, `gridtk list` outputs a table which migh not fit the terminal width.
+You can adjust the output using the `--wrap` and `--truncate` flags. The `--wrap`
+flag wraps the output to fit the terminal width, while the `--truncate` flag
+truncates the output to fit the terminal width.
 
 ```bash
 $ gridtk list
-  job-id    slurm-  nodes    state           job-    output           depende    command
-                id                           name                     ncies
---------  --------  -------  --------------  ------  ---------------  ---------  --------------------
-       1    506976  None     UNKNOWN (None)  gridtk  logs/gridtk.506             gridtk submit job.sh
-                                                     976.out
-
-$ gridtk list --full-output
   job-id    slurm-id  nodes    state          job-name    output                  dependencies    command
 --------  ----------  -------  -------------  ----------  ----------------------  --------------  --------------------
-       1      506976  hcne01   COMPLETED (0)  gridtk      logs/gridtk.506976.out                  gridtk submit job.sh
+       1      506993  hcne01   COMPLETED (0)  gridtk      logs/gridtk.506993.out                  gridtk submit job.sh
 
-$ gridtk list --truncate
-  job-id    slurm-  nodes    state          job-    output           depende    command
-                id                          name                     ncies
---------  --------  -------  -------------  ------  ---------------  ---------  --------------------
-       1    506976  hcne01   COMPLETED (0)  gridtk  logs/gridtk....             gridtk submit job.sh
+$ gridtk list --wrap  # --wrap or -w
+  job-id    slurm-  nodes    state      job-name    output               depende    command
+                id                                                       ncies
+--------  --------  -------  ---------  ----------  -------------------  ---------  -------------
+       1    506993  hcne01   COMPLETED  gridtk      logs/gridtk.506993.             gridtk submit
+                             (0)                    out                             job.sh
+
+$ gridtk list --truncate # --truncate or -t
+  job-id    slur..  nodes    state     job-name    output              depe..    command
+--------  --------  -------  --------  ----------  ------------------  --------  -----------------
+       1    506993  hcne01   COMPLE..  gridtk      logs/gridtk.5069..            gridtk submit j..
 ```

--- a/README.md
+++ b/README.md
@@ -251,3 +251,16 @@ or for `zsh` add the following line to your `~/.zshrc` file:
 ```bash
 eval "$(_GRIDTK_COMPLETE=zsh_source gridtk)"
 ```
+
+### Adjusting `gridtk list` Output to Fit Terminal Width
+
+By default, the `gridtk list` output now adjusts to fit the terminal width, with truncation or ellipses for long content. This ensures that the output remains readable and does not span multiple lines. If you wish to view the full output without truncation, you can use the `--full-output` option:
+
+```bash
+$ gridtk list --full-output
+  job-id    grid-id  nodes    state        job-name    output                  dependencies    command
+--------  ---------  -------  -----------  ----------  ----------------------  --------------  --------------------
+       1     136132  None     PENDING (0)  gridtk      logs/gridtk.136132.out                  gridtk submit job.sh
+```
+
+This enhancement improves readability and allows you to quickly parse job-related information without resizing your terminal or handling multiline outputs for each job.

--- a/README.md
+++ b/README.md
@@ -263,17 +263,17 @@ truncates the output to fit the terminal width.
 $ gridtk list
   job-id    slurm-id  nodes    state          job-name    output                  dependencies    command
 --------  ----------  -------  -------------  ----------  ----------------------  --------------  --------------------
-       1      506993  hcne01   COMPLETED (0)  gridtk      logs/gridtk.506993.out                  gridtk submit job.sh
+       1      506994  hcne01   COMPLETED (0)  gridtk      logs/gridtk.506994.out                  gridtk submit job.sh
 
 $ gridtk list --wrap  # --wrap or -w
-  job-id    slurm-  nodes    state      job-name    output               depende    command
-                id                                                       ncies
---------  --------  -------  ---------  ----------  -------------------  ---------  -------------
-       1    506993  hcne01   COMPLETED  gridtk      logs/gridtk.506993.             gridtk submit
-                             (0)                    out                             job.sh
+  job-id    slurm-  nodes    state     job-name    output             depende    command
+                id                                                    ncies
+--------  --------  -------  --------  ----------  -----------------  ---------  -------------
+       1    506994  hcne0    COMPLETE  gridtk      logs/gridtk.50699             gridtk submit
+                    1        D (0)                 4.out                         job.sh
 
 $ gridtk list --truncate # --truncate or -t
-  job-id    slur..  nodes    state     job-name    output              depe..    command
---------  --------  -------  --------  ----------  ------------------  --------  -----------------
-       1    506993  hcne01   COMPLE..  gridtk      logs/gridtk.5069..            gridtk submit j..
+  job-id    slur..  nodes    state    job-name    output            depe..    command
+--------  --------  -------  -------  ----------  ----------------  --------  -------------
+       1    506994  hc..     COMPL..  gridtk      logs/gridtk.50..            gridtk subm..
 ```

--- a/README.md
+++ b/README.md
@@ -252,15 +252,27 @@ or for `zsh` add the following line to your `~/.zshrc` file:
 eval "$(_GRIDTK_COMPLETE=zsh_source gridtk)"
 ```
 
-### Adjusting `gridtk list` Output to Fit Terminal Width
+### Adjusting `gridtk list` Output
 
-By default, the `gridtk list` output now adjusts to fit the terminal width, with truncation or ellipses for long content. This ensures that the output remains readable and does not span multiple lines. If you wish to view the full output without truncation, you can use the `--full-output` option:
+By default, the `gridtk list` output adjusts to fit the terminal width, with wraping. There are two options: `--truncate` and `--full-output`.
+The `--truncate` option truncates the output to fit the terminal width, while the `--full-output` option displays the full output without wrapping.
 
 ```bash
-$ gridtk list --full-output
-  job-id    grid-id  nodes    state        job-name    output                  dependencies    command
---------  ---------  -------  -----------  ----------  ----------------------  --------------  --------------------
-       1     136132  None     PENDING (0)  gridtk      logs/gridtk.136132.out                  gridtk submit job.sh
-```
+$ gridtk list
+  job-id    slurm-  nodes    state           job-    output           depende    command
+                id                           name                     ncies
+--------  --------  -------  --------------  ------  ---------------  ---------  --------------------
+       1    506976  None     UNKNOWN (None)  gridtk  logs/gridtk.506             gridtk submit job.sh
+                                                     976.out
 
-This enhancement improves readability and allows you to quickly parse job-related information without resizing your terminal or handling multiline outputs for each job.
+$ gridtk list --full-output
+  job-id    slurm-id  nodes    state          job-name    output                  dependencies    command
+--------  ----------  -------  -------------  ----------  ----------------------  --------------  --------------------
+       1      506976  hcne01   COMPLETED (0)  gridtk      logs/gridtk.506976.out                  gridtk submit job.sh
+
+$ gridtk list --truncate
+  job-id    slurm-  nodes    state          job-    output           depende    command
+                id                          name                     ncies
+--------  --------  -------  -------------  ------  ---------------  ---------  --------------------
+       1    506976  hcne01   COMPLETED (0)  gridtk  logs/gridtk....             gridtk submit job.sh
+```

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -478,13 +478,6 @@ def list_jobs(
             for key, value in max_widths.items():
                 if isinstance(value, float):
                     max_widths[key] = int(left_over_width * value)
-            left_over_width = (
-                terminal_width
-                - width_of_spaces
-                - sum(v for v in max_widths.values() if isinstance(v, int))
-            )
-            # distribute the left over width to the command column
-            max_widths["command"] += left_over_width
             maxcolwidths = [int(max_widths[key]) for key in table]
             if truncate:
                 for key, rows in table.items():

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -436,7 +436,7 @@ def list_jobs(
         for job in jobs:
             table["job-id"].append(job.id)
             table["slurm-id"].append(job.grid_id)
-            table["nodes"].append(job.nodes)
+            table["nodes"].append(str(job.nodes))
             table["state"].append(f"{job.state} ({job.exit_code})")
             table["job-name"].append(job.name)
             output = job.output_files[0].resolve()
@@ -468,14 +468,15 @@ def list_jobs(
             else:
                 maxcolwidths = [max_widths.get(key, 15) for key in table]
 
-        click.echo(
-            tabulate(
-                table,
-                headers="keys",
-                maxcolwidths=maxcolwidths,
-                maxheadercolwidths=None if full_output else 7,
+        if table:
+            click.echo(
+                tabulate(
+                    table,
+                    headers="keys",
+                    maxcolwidths=maxcolwidths,
+                    maxheadercolwidths=None if full_output else 7,
+                )
             )
-        )
         session.commit()
 
 

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -260,7 +260,7 @@ def test_list_jobs(mock_check_output, runner):
             ["sacct", "-j", str(submit_job_id), "--json"], text=True
         )
         # truncated command
-        assert "gridtk sub..\n" in result.output
+        assert "gridtk s..\n" in result.output
         # truncated log file name
         assert "logs/gridt.. " in result.output
 

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -228,6 +228,11 @@ def test_submit_triple_dash(mock_check_output: Mock, runner):
 @patch("subprocess.check_output")
 def test_list_jobs(mock_check_output, runner):
     with runner.isolated_filesystem():
+        # test when there are no jobs
+        result = runner.invoke(cli, ["list"])
+        assert_click_runner_result(result)
+        assert result.output == ""
+        # test when there are jobs
         submit_job_id = 9876543
         _submit_job(
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
@@ -532,8 +537,9 @@ def test_list_jobs_with_truncation(mock_check_output, runner):
         result = runner.invoke(cli, ["list"])
         assert_click_runner_result(result)
         assert str(submit_job_id) in result.output
-        assert "gridtk submit --- sleep" in result.output
-        assert "logs/gridtk.9876543.out" in result.output
+        assert "gridtk submit --wrap sleep" in result.output
+        # truncated log file name
+        assert "logs/gridtk.987 " in result.output
         mock_check_output.assert_called_with(
             ["sacct", "-j", str(submit_job_id), "--json"], text=True
         )
@@ -551,7 +557,7 @@ def test_list_jobs_with_full_output(mock_check_output, runner):
         result = runner.invoke(cli, ["list", "--full-output"])
         assert_click_runner_result(result)
         assert str(submit_job_id) in result.output
-        assert "gridtk submit --- sleep" in result.output
+        assert "gridtk submit --wrap sleep" in result.output
         assert "logs/gridtk.9876543.out" in result.output
         mock_check_output.assert_called_with(
             ["sacct", "-j", str(submit_job_id), "--json"], text=True

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -559,45 +559,6 @@ Deleted job 5 with slurm id {third_grid_id + 10}
         )
 
 
-# @patch("subprocess.check_output")
-# def test_list_jobs_with_truncation(mock_check_output, runner):
-#     with runner.isolated_filesystem():
-#         submit_job_id = 9876543
-#         _submit_job(
-#             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
-#         )
-
-#         mock_check_output.return_value = _pending_job_sacct_json(submit_job_id)
-#         result = runner.invoke(cli, ["list"])
-#         assert_click_runner_result(result)
-#         assert str(submit_job_id) in result.output
-#         assert "gridtk submit --wrap sleep" in result.output
-#         # wraped log file name
-#         assert "logs/gridtk.987 " in result.output
-#         mock_check_output.assert_called_with(
-#             ["sacct", "-j", str(submit_job_id), "--json"], text=True
-#         )
-
-
-# @patch("subprocess.check_output")
-# def test_list_jobs_with_full_output(mock_check_output, runner):
-#     with runner.isolated_filesystem():
-#         submit_job_id = 9876543
-#         _submit_job(
-#             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
-#         )
-
-#         mock_check_output.return_value = _pending_job_sacct_json(submit_job_id)
-#         result = runner.invoke(cli, ["list", "--full-output"])
-#         assert_click_runner_result(result)
-#         assert str(submit_job_id) in result.output
-#         assert "gridtk submit --wrap sleep" in result.output
-#         assert "logs/gridtk.9876543.out" in result.output
-#         mock_check_output.assert_called_with(
-#             ["sacct", "-j", str(submit_job_id), "--json"], text=True
-#         )
-
-
 if __name__ == "__main__":
     import sys
 

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -520,6 +520,44 @@ Deleted job 5 with slurm id {third_grid_id + 10}
         )
 
 
+@patch("subprocess.check_output")
+def test_list_jobs_with_truncation(mock_check_output, runner):
+    with runner.isolated_filesystem():
+        submit_job_id = 9876543
+        _submit_job(
+            runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
+        )
+
+        mock_check_output.return_value = _pending_job_sacct_json(submit_job_id)
+        result = runner.invoke(cli, ["list"])
+        assert_click_runner_result(result)
+        assert str(submit_job_id) in result.output
+        assert "gridtk submit --- sleep" in result.output
+        assert "logs/gridtk.9876543.out" in result.output
+        mock_check_output.assert_called_with(
+            ["sacct", "-j", str(submit_job_id), "--json"], text=True
+        )
+
+
+@patch("subprocess.check_output")
+def test_list_jobs_with_full_output(mock_check_output, runner):
+    with runner.isolated_filesystem():
+        submit_job_id = 9876543
+        _submit_job(
+            runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
+        )
+
+        mock_check_output.return_value = _pending_job_sacct_json(submit_job_id)
+        result = runner.invoke(cli, ["list", "--full-output"])
+        assert_click_runner_result(result)
+        assert str(submit_job_id) in result.output
+        assert "gridtk submit --- sleep" in result.output
+        assert "logs/gridtk.9876543.out" in result.output
+        mock_check_output.assert_called_with(
+            ["sacct", "-j", str(submit_job_id), "--json"], text=True
+        )
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
Fixes #13. By default, `gridtk list` outputs a table which migh not fit the terminal width.
This PR adds options to adjust the output using the `--wrap` and `--truncate` flags. The `--wrap`
flag wraps the output to fit the terminal width, while the `--truncate` flag
truncates the output to fit the terminal width.

<!-- readthedocs-preview gridtk start -->
----
📚 Documentation preview 📚: https://gridtk--15.org.readthedocs.build/en/15/

<!-- readthedocs-preview gridtk end -->