### PR TITLE
feat: CLI options can be supplied using env vars

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,3 +16,6 @@ python:
       path: .
       extra_requirements:
         - doc
+
+sphinx:
+  configuration: doc/conf.py

--- a/README.md
+++ b/README.md
@@ -198,6 +198,26 @@ This is a fast, convenient, and **recommended** way to submit a job without havi
 script and since everything is tracked by GridTK, you still benefit from the same
 reproducibility guarantees.
 
+### Environment Variables for CLI Options
+
+While sbatch already allows providing values for some options through `SBATCH_` prefixed environment variables, not all options are supported. GridTK adds support for all CLI options through the `GRIDTK_SUBMIT_` prefix. For example:
+
+```bash
+# Set default email notification settings
+export GRIDTK_SUBMIT_MAIL_USER=your.email@example.com
+export GRIDTK_SUBMIT_MAIL_TYPE=END
+
+# Use debug partition by default
+export GRIDTK_SUBMIT_PARTITION=debug
+
+# Now submit a job - it will use these settings automatically
+gridtk submit job.sh
+```
+
+This is useful when you have a set of options that you always want to use, but don't want to specify them every time you submit a job.
+
+Of course, other gridtk commands such as `gridtk resubmit` options can also be set using environment variables like: `export GRIDTK_RESUBMIT_STATE=ALL`.
+
 ### Job Dependencies
 
 To submit a job that depends on another job, use the `--dependency` flag:

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -142,6 +142,7 @@ def job_filters(f_py=None, default_states=None):
     context_settings={
         "show_default": True,
         "help_option_names": ["--help", "-h"],
+        "auto_envvar_prefix": "GRIDTK",
     },
 )
 @click.option(


### PR DESCRIPTION
Although sbatch already allows providing values for options through SBATCH_ prefixed env vars, not all options are supported. This change adds support for all options of sbatch through a GRIDTK_SUBMIT_ prefix. For example, to always get emails when a job finishes, you can set GRIDTK_SUBMIT_MAIL_USER to your email address and GRIDTK_SUBMIT_MAIL_TYPE to END. This is useful when you have a set of options that you always want to use, but don't want to specify them every time you submit a job. Of course, other gridtk commands such as `gridtk resubmit` options can also be set using environment variables like: `export GRIDTK_RESUBMIT_STATE=ALL`.

fix: explicitly speficy the sphinx.configuration key in Read the Docs setup

<!-- readthedocs-preview gridtk start -->
----
📚 Documentation preview 📚: https://gridtk--18.org.readthedocs.build/en/18/

<!-- readthedocs-preview gridtk end -->