### PR TITLE
fix: show feedback when commands match no jobs

### DIFF
--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -523,9 +523,7 @@ def list_jobs(
                 )
             )
         else:
-            click.echo(
-                no_jobs_message("found")
-            )
+            click.echo(no_jobs_message("found"))
         session.commit()
 
 
@@ -548,9 +546,7 @@ def stop(
             job_ids=job_ids, states=states, names=names, dependents=dependents
         )
         if not jobs:
-            click.echo(
-                no_jobs_message("stopped")
-            )
+            click.echo(no_jobs_message("stopped"))
         for job in jobs:
             click.echo(f"Stopped job {job.id} with slurm id {job.grid_id}")
         session.commit()
@@ -575,9 +571,7 @@ def delete(
             job_ids=job_ids, states=states, names=names, dependents=dependents
         )
         if not jobs:
-            click.echo(
-                no_jobs_message("deleted")
-            )
+            click.echo(no_jobs_message("deleted"))
         for job in jobs:
             click.echo(f"Deleted job {job.id} with slurm id {job.grid_id}")
         session.commit()
@@ -609,9 +603,7 @@ def report(
             job_ids=job_ids, states=states, names=names, dependents=dependents
         )
         if not jobs:
-            click.echo(
-                no_jobs_message("found")
-            )
+            click.echo(no_jobs_message("found"))
         for job in jobs:
             report_text = ""
             report_text += f"Job ID: {job.id}\n"

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -94,6 +94,33 @@ def states_callback(ctx, param, value):
     return parse_states(value)
 
 
+def no_jobs_message(
+    action: str,
+    *,
+    job_ids: list[int],
+    states: list[str],
+    names: list[str],
+) -> str:
+    """Build a helpful message when no jobs match the given filters."""
+    msg = f"No jobs were {action}."
+    filters = []
+    if job_ids:
+        job_ids_str = ",".join(str(j) for j in job_ids)
+        filters.append(f"--jobs {job_ids_str}")
+    if states:
+        states_str = ",".join(states)
+        filters.append(f"--state {states_str}")
+    if names:
+        names_str = " --name ".join(names)
+        filters.append(f"--name {names_str}")
+    if filters:
+        filters_str = " ".join(filters)
+        msg += f" Active filters: {filters_str}"
+    else:
+        msg += " No jobs exist in the database."
+    return msg
+
+
 def job_filters(f_py=None, default_states=None):
     """Filter jobs based on the provided function and default states."""
     assert callable(f_py) or f_py is None
@@ -389,10 +416,9 @@ def resubmit(
         )
         if not jobs:
             click.echo(
-                "No jobs were resubmitted. Note that the default state "
-                "filtering may have excluded some jobs. If you want to "
-                "resubmit all jobs, please use the option: "
-                "gridtk resubmit --state all"
+                no_jobs_message(
+                    "resubmitted", job_ids=job_ids, states=states, names=names
+                )
             )
         for job in jobs:
             click.echo(f"Resubmitted job {job.id}")
@@ -508,7 +534,9 @@ def list_jobs(
                 )
             )
         else:
-            click.echo("No jobs found.")
+            click.echo(
+                no_jobs_message("found", job_ids=job_ids, states=states, names=names)
+            )
         session.commit()
 
 
@@ -531,7 +559,9 @@ def stop(
             job_ids=job_ids, states=states, names=names, dependents=dependents
         )
         if not jobs:
-            click.echo("No jobs were stopped.")
+            click.echo(
+                no_jobs_message("stopped", job_ids=job_ids, states=states, names=names)
+            )
         for job in jobs:
             click.echo(f"Stopped job {job.id} with slurm id {job.grid_id}")
         session.commit()
@@ -556,7 +586,9 @@ def delete(
             job_ids=job_ids, states=states, names=names, dependents=dependents
         )
         if not jobs:
-            click.echo("No jobs were deleted.")
+            click.echo(
+                no_jobs_message("deleted", job_ids=job_ids, states=states, names=names)
+            )
         for job in jobs:
             click.echo(f"Deleted job {job.id} with slurm id {job.grid_id}")
         session.commit()
@@ -588,7 +620,9 @@ def report(
             job_ids=job_ids, states=states, names=names, dependents=dependents
         )
         if not jobs:
-            click.echo("No jobs found.")
+            click.echo(
+                no_jobs_message("found", job_ids=job_ids, states=states, names=names)
+            )
         for job in jobs:
             report_text = ""
             report_text += f"Job ID: {job.id}\n"

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -507,6 +507,8 @@ def list_jobs(
                     maxheadercolwidths=maxcolwidths,
                 )
             )
+        else:
+            click.echo("No jobs found.")
         session.commit()
 
 
@@ -528,6 +530,8 @@ def stop(
         jobs = job_manager.stop_jobs(
             job_ids=job_ids, states=states, names=names, dependents=dependents
         )
+        if not jobs:
+            click.echo("No jobs were stopped.")
         for job in jobs:
             click.echo(f"Stopped job {job.id} with slurm id {job.grid_id}")
         session.commit()
@@ -551,6 +555,8 @@ def delete(
         jobs = job_manager.delete_jobs(
             job_ids=job_ids, states=states, names=names, dependents=dependents
         )
+        if not jobs:
+            click.echo("No jobs were deleted.")
         for job in jobs:
             click.echo(f"Deleted job {job.id} with slurm id {job.grid_id}")
         session.commit()
@@ -581,6 +587,8 @@ def report(
         jobs = job_manager.list_jobs(
             job_ids=job_ids, states=states, names=names, dependents=dependents
         )
+        if not jobs:
+            click.echo("No jobs found.")
         for job in jobs:
             report_text = ""
             report_text += f"Job ID: {job.id}\n"

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -100,24 +100,24 @@ def no_jobs_message(
     job_ids: list[int],
     states: list[str],
     names: list[str],
+    default_states: bool = False,
 ) -> str:
     """Build a helpful message when no jobs match the given filters."""
     msg = f"No jobs were {action}."
-    filters = []
-    if job_ids:
-        job_ids_str = ",".join(str(j) for j in job_ids)
-        filters.append(f"--jobs {job_ids_str}")
-    if states:
-        states_str = ",".join(states)
-        filters.append(f"--state {states_str}")
-    if names:
-        names_str = " --name ".join(names)
-        filters.append(f"--name {names_str}")
-    if filters:
-        filters_str = " ".join(filters)
-        msg += f" Active filters: {filters_str}"
-    else:
-        msg += " No jobs exist in the database."
+    if states and default_states:
+        msg += (
+            " Note: the default state filter is active."
+            " Use --state all to include all jobs."
+        )
+    elif job_ids or states or names:
+        filters = []
+        if job_ids:
+            filters.append(f"--jobs {','.join(str(j) for j in job_ids)}")
+        if states:
+            filters.append(f"--state {','.join(states)}")
+        if names:
+            filters.append(f"--name {' --name '.join(names)}")
+        msg += f" Active filters: {' '.join(filters)}"
     return msg
 
 
@@ -417,7 +417,11 @@ def resubmit(
         if not jobs:
             click.echo(
                 no_jobs_message(
-                    "resubmitted", job_ids=job_ids, states=states, names=names
+                    "resubmitted",
+                    job_ids=job_ids,
+                    states=states,
+                    names=names,
+                    default_states=True,
                 )
             )
         for job in jobs:

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -97,27 +97,15 @@ def states_callback(ctx, param, value):
 def no_jobs_message(
     action: str,
     *,
-    job_ids: list[int],
-    states: list[str],
-    names: list[str],
     default_states: bool = False,
 ) -> str:
     """Build a helpful message when no jobs match the given filters."""
     msg = f"No jobs were {action}."
-    if states and default_states:
+    if default_states:
         msg += (
             " Note: the default state filter is active."
             " Use --state all to include all jobs."
         )
-    elif job_ids or states or names:
-        filters = []
-        if job_ids:
-            filters.append(f"--jobs {','.join(str(j) for j in job_ids)}")
-        if states:
-            filters.append(f"--state {','.join(states)}")
-        if names:
-            filters.append(f"--name {' --name '.join(names)}")
-        msg += f" Active filters: {' '.join(filters)}"
     return msg
 
 
@@ -418,9 +406,6 @@ def resubmit(
             click.echo(
                 no_jobs_message(
                     "resubmitted",
-                    job_ids=job_ids,
-                    states=states,
-                    names=names,
                     default_states=True,
                 )
             )
@@ -539,7 +524,7 @@ def list_jobs(
             )
         else:
             click.echo(
-                no_jobs_message("found", job_ids=job_ids, states=states, names=names)
+                no_jobs_message("found")
             )
         session.commit()
 
@@ -564,7 +549,7 @@ def stop(
         )
         if not jobs:
             click.echo(
-                no_jobs_message("stopped", job_ids=job_ids, states=states, names=names)
+                no_jobs_message("stopped")
             )
         for job in jobs:
             click.echo(f"Stopped job {job.id} with slurm id {job.grid_id}")
@@ -591,7 +576,7 @@ def delete(
         )
         if not jobs:
             click.echo(
-                no_jobs_message("deleted", job_ids=job_ids, states=states, names=names)
+                no_jobs_message("deleted")
             )
         for job in jobs:
             click.echo(f"Deleted job {job.id} with slurm id {job.grid_id}")
@@ -625,7 +610,7 @@ def report(
         )
         if not jobs:
             click.echo(
-                no_jobs_message("found", job_ids=job_ids, states=states, names=names)
+                no_jobs_message("found")
             )
         for job in jobs:
             report_text = ""

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -286,7 +286,7 @@ def test_list_jobs(mock_check_output, runner):
         # test when there are no jobs
         result = runner.invoke(cli, ["list"])
         assert_click_runner_result(result)
-        assert result.output == ""
+        assert result.output == "No jobs found.\n"
 
         # test when there are jobs
         submit_job_id = 9876543

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -287,7 +287,6 @@ def test_list_jobs(mock_check_output, runner):
         result = runner.invoke(cli, ["list"])
         assert_click_runner_result(result)
         assert "No jobs were found." in result.output
-        assert "No jobs exist in the database." in result.output
 
         # test when there are jobs
         submit_job_id = 9876543
@@ -498,7 +497,8 @@ def test_resubmit_no_jobs(mock_check_output, runner):
         result = runner.invoke(cli, ["resubmit"])
         assert_click_runner_result(result)
         assert "No jobs were resubmitted." in result.output
-        assert "Active filters:" in result.output
+        assert "default state filter" in result.output
+        assert "--state all" in result.output
 
 
 @patch("subprocess.check_output")

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -286,7 +286,8 @@ def test_list_jobs(mock_check_output, runner):
         # test when there are no jobs
         result = runner.invoke(cli, ["list"])
         assert_click_runner_result(result)
-        assert result.output == "No jobs found.\n"
+        assert "No jobs were found." in result.output
+        assert "No jobs exist in the database." in result.output
 
         # test when there are jobs
         submit_job_id = 9876543
@@ -496,8 +497,8 @@ def test_resubmit_no_jobs(mock_check_output, runner):
         )
         result = runner.invoke(cli, ["resubmit"])
         assert_click_runner_result(result)
-        assert "No jobs were resubmitted" in result.output
-        assert "gridtk resubmit --state all" in result.output
+        assert "No jobs were resubmitted." in result.output
+        assert "Active filters:" in result.output
 
 
 @patch("subprocess.check_output")


### PR DESCRIPTION
## Summary
- Show feedback when commands match no jobs instead of silent no-op
- Only `resubmit` hints about its default state filter since users may not realize it's active

### Examples
```
$ gridtk list
No jobs were found.

$ gridtk resubmit
No jobs were resubmitted. Note: the default state filter is active. Use --state all to include all jobs.

$ gridtk stop
No jobs were stopped.

$ gridtk delete
No jobs were deleted.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview gridtk start -->
----
📚 Documentation preview 📚: https://gridtk--27.org.readthedocs.build/en/27/

<!-- readthedocs-preview gridtk end -->