### PR TITLE
feat: add wait command with non-zero exit on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,27 @@ Here are some useful commands:
   sacctmgr -n -p list assoc where user=$USER | awk '-F|' '{print "   "$2}'
   ```
 
+### Waiting for Jobs
+
+Use `gridtk wait` to block until all jobs finish:
+```bash
+$ gridtk wait
+Waiting for 3 job(s)... (checking every 10s)
+Job 1: COMPLETED (0)
+Job 2: COMPLETED (0)
+Job 3: FAILED (1)
+```
+
+`gridtk wait` exits with code 1 if any job failed, making it easy to chain:
+```bash
+$ gridtk submit job.sh && gridtk wait && echo "All done!"
+```
+
+You can filter which jobs to wait for and change the polling interval:
+```bash
+$ gridtk wait -j 1,2 --interval 30
+```
+
 ### Tab Completion
 
 GridTK supports tab completion for the `gridtk` command. To enable it, add the following

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -704,9 +704,7 @@ def wait(ctx, job_ids, states, names, dependents, interval):
 
             active = [j for j in jobs if j.state not in terminal_states]
             counts = Counter(j.state for j in active)
-            breakdown = ", ".join(
-                f"{n} {s.lower()}" for s, n in sorted(counts.items())
-            )
+            breakdown = ", ".join(f"{n} {s.lower()}" for s, n in sorted(counts.items()))
             click.echo(
                 f"Waiting for {len(active)} job(s): {breakdown}"
                 f" (checking every {interval}s)"

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -695,7 +695,7 @@ def wait(ctx, job_ids, states, names, dependents, interval):
                 for job in jobs:
                     click.echo(f"Job {job.id}: {job.state} ({job.exit_code})")
                 if any_failed:
-                    ctx.exit(1)
+                    raise SystemExit(1)
                 return
 
             # Show progress

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -694,6 +694,7 @@ def wait(ctx, job_ids, states, names, dependents, interval):
                 any_failed = any(job.state in failed_states for job in jobs)
                 for job in jobs:
                     click.echo(f"Job {job.id}: {job.state} ({job.exit_code})")
+                session.commit()
                 if any_failed:
                     raise SystemExit(1)
                 return

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -186,9 +186,10 @@ def cli(ctx, database, logs_dir):
 
 @cli.result_callback()
 def process_result(result, **kwargs):
-    """Delete the job manager from the context."""
+    """Clean up empty databases and dispose the job manager."""
     ctx = click.get_current_context()
-    del ctx.meta["job_manager"]
+    job_manager = ctx.meta.pop("job_manager")
+    job_manager.cleanup_empty_database()
 
 
 @cli.command(

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -699,9 +699,18 @@ def wait(ctx, job_ids, states, names, dependents, interval):
                     raise SystemExit(1)
                 return
 
-            # Show progress
-            pending = sum(1 for j in jobs if j.state not in terminal_states)
-            click.echo(f"Waiting for {pending} job(s)... (checking every {interval}s)")
+            # Show progress with state breakdown
+            from collections import Counter
+
+            active = [j for j in jobs if j.state not in terminal_states]
+            counts = Counter(j.state for j in active)
+            breakdown = ", ".join(
+                f"{n} {s.lower()}" for s, n in sorted(counts.items())
+            )
+            click.echo(
+                f"Waiting for {len(active)} job(s): {breakdown}"
+                f" (checking every {interval}s)"
+            )
             session.commit()
 
         time.sleep(interval)

--- a/src/gridtk/cli.py
+++ b/src/gridtk/cli.py
@@ -639,6 +639,76 @@ def delete(
 @cli.command()
 @job_filters
 @click.option(
+    "--interval",
+    default=10,
+    type=click.INT,
+    help="Polling interval in seconds.",
+)
+@click.pass_context
+def wait(ctx, job_ids, states, names, dependents, interval):
+    """Wait for jobs to finish. Exits with code 1 if any job failed."""
+    import time
+
+    from .manager import JobManager
+
+    job_manager: JobManager = ctx.meta["job_manager"]
+    # Terminal states - jobs in these states won't change
+    terminal_states = {
+        "BOOT_FAIL",
+        "CANCELLED",
+        "COMPLETED",
+        "DEADLINE",
+        "FAILED",
+        "NODE_FAIL",
+        "OUT_OF_MEMORY",
+        "PREEMPTED",
+        "REVOKED",
+        "SPECIAL_EXIT",
+        "TIMEOUT",
+    }
+    # Failed states - if any job ends in these, exit code 1
+    failed_states = {
+        "BOOT_FAIL",
+        "CANCELLED",
+        "DEADLINE",
+        "FAILED",
+        "NODE_FAIL",
+        "OUT_OF_MEMORY",
+        "PREEMPTED",
+        "REVOKED",
+        "SPECIAL_EXIT",
+        "TIMEOUT",
+    }
+
+    while True:
+        with job_manager as session:
+            jobs = job_manager.list_jobs(
+                job_ids=job_ids, states=states, names=names, dependents=dependents
+            )
+            if not jobs:
+                click.echo("No jobs found.")
+                return
+
+            all_terminal = all(job.state in terminal_states for job in jobs)
+            if all_terminal:
+                any_failed = any(job.state in failed_states for job in jobs)
+                for job in jobs:
+                    click.echo(f"Job {job.id}: {job.state} ({job.exit_code})")
+                if any_failed:
+                    ctx.exit(1)
+                return
+
+            # Show progress
+            pending = sum(1 for j in jobs if j.state not in terminal_states)
+            click.echo(f"Waiting for {pending} job(s)... (checking every {interval}s)")
+            session.commit()
+
+        time.sleep(interval)
+
+
+@cli.command()
+@job_filters
+@click.option(
     "-a",
     "--array",
     "array_idx",

--- a/src/gridtk/manager.py
+++ b/src/gridtk/manager.py
@@ -302,8 +302,8 @@ dependencies: {dependencies}"""
             self.session.add(job)
         return jobs
 
-    def __del__(self):
-        # if there are no jobs in the database, delete the database file and the logs directory (if empty)
+    def cleanup_empty_database(self):
+        """Delete the database file and logs directory if no jobs remain."""
         with self:
             if (
                 Path(self.database).exists()
@@ -312,4 +312,6 @@ dependencies: {dependencies}"""
                 Path(self.database).unlink()
                 if self.logs_dir.exists() and len(os.listdir(self.logs_dir)) == 0:
                     shutil.rmtree(self.logs_dir)
+
+    def __del__(self):
         self.engine.dispose()

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -747,6 +747,9 @@ def test_wait_command(mock_check_output, runner):
         mock_check_output.return_value = json.dumps(
             _jobs_sacct_dict([submit_job_id], "COMPLETED", "None", "node001")
         )
+        # Debug: verify job exists in DB before wait
+        result = runner.invoke(cli, ["list"])
+        assert "gridtk" in result.output, f"list before wait: {result.output!r}"
         result = runner.invoke(cli, ["wait"])
         assert_click_runner_result(result)
         assert "Job 1: COMPLETED" in result.output

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -742,14 +742,12 @@ def test_wait_command(mock_check_output, runner):
         _submit_job(
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
         )
-        # Force GC to run __del__ on submit's JobManager before changing mock
+        # Force GC and ensure DB survives __del__ cleanup
         gc.collect()
+        assert Path("jobs.sql3").exists(), "DB was deleted by __del__"
         mock_check_output.return_value = json.dumps(
             _jobs_sacct_dict([submit_job_id], "COMPLETED", "None", "node001")
         )
-        # Debug: verify job exists in DB before wait
-        result = runner.invoke(cli, ["list"])
-        assert "gridtk" in result.output, f"list before wait: {result.output!r}"
         result = runner.invoke(cli, ["wait"])
         assert_click_runner_result(result)
         assert "Job 1: COMPLETED" in result.output
@@ -762,6 +760,7 @@ def test_wait_command(mock_check_output, runner):
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
         )
         gc.collect()
+        assert Path("jobs.sql3").exists(), "DB was deleted by __del__"
         mock_check_output.return_value = _failed_job_sacct_json(submit_job_id)
         result = runner.invoke(cli, ["wait"])
         assert_click_runner_result(result, exit_code=1)

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -8,6 +8,8 @@ import stat
 import subprocess
 import traceback
 
+import gridtk.manager
+
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -697,13 +699,25 @@ Deleted job 5 with slurm id {third_grid_id + 10}
 @patch("subprocess.check_output")
 def test_list_json(mock_check_output, runner):
     import gc
+    import os
+
+    original_del = gridtk.manager.JobManager.__del__
+
+    def debug_del(self):
+        print(f"DEBUG __del__: DB={self.database}, exists={Path(self.database).exists()}")
+        original_del(self)
+        print(f"DEBUG __del__ after: exists={Path(self.database).exists()}")
 
     with runner.isolated_filesystem():
         submit_job_id = 9876543
         _submit_job(
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
         )
+        print(f"DEBUG after submit: DB exists={os.path.exists('jobs.sql3')}")
+        gridtk.manager.JobManager.__del__ = debug_del
         gc.collect()
+        print(f"DEBUG after gc: DB exists={os.path.exists('jobs.sql3')}")
+        gridtk.manager.JobManager.__del__ = original_del
         mock_check_output.return_value = _pending_job_sacct_json(submit_job_id)
         result = runner.invoke(cli, ["list", "--json"])
         assert_click_runner_result(result)
@@ -734,19 +748,15 @@ def test_submit_json(mock_check_output, runner):
         assert data["name"] == "gridtk"
 
 
+@patch("gridtk.manager.JobManager.__del__", lambda self: None)
 @patch("subprocess.check_output")
 def test_wait_command(mock_check_output, runner):
-    import gc
-
     # Test wait with COMPLETED job (exit code 0)
     with runner.isolated_filesystem():
         submit_job_id = 9876543
         _submit_job(
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
         )
-        # Force GC and ensure DB survives __del__ cleanup
-        gc.collect()
-        assert Path("jobs.sql3").exists(), "DB was deleted by __del__"
         mock_check_output.return_value = json.dumps(
             _jobs_sacct_dict([submit_job_id], "COMPLETED", "None", "node001")
         )
@@ -761,8 +771,6 @@ def test_wait_command(mock_check_output, runner):
         _submit_job(
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
         )
-        gc.collect()
-        assert Path("jobs.sql3").exists(), "DB was deleted by __del__"
         mock_check_output.return_value = _failed_job_sacct_json(submit_job_id)
         result = runner.invoke(cli, ["wait"])
         assert_click_runner_result(result, exit_code=1)

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -8,8 +8,6 @@ import stat
 import subprocess
 import traceback
 
-import gridtk.manager
-
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -698,26 +696,11 @@ Deleted job 5 with slurm id {third_grid_id + 10}
 
 @patch("subprocess.check_output")
 def test_list_json(mock_check_output, runner):
-    import gc
-    import os
-
-    original_del = gridtk.manager.JobManager.__del__
-
-    def debug_del(self):
-        print(f"DEBUG __del__: DB={self.database}, exists={Path(self.database).exists()}")
-        original_del(self)
-        print(f"DEBUG __del__ after: exists={Path(self.database).exists()}")
-
     with runner.isolated_filesystem():
         submit_job_id = 9876543
         _submit_job(
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
         )
-        print(f"DEBUG after submit: DB exists={os.path.exists('jobs.sql3')}")
-        gridtk.manager.JobManager.__del__ = debug_del
-        gc.collect()
-        print(f"DEBUG after gc: DB exists={os.path.exists('jobs.sql3')}")
-        gridtk.manager.JobManager.__del__ = original_del
         mock_check_output.return_value = _pending_job_sacct_json(submit_job_id)
         result = runner.invoke(cli, ["list", "--json"])
         assert_click_runner_result(result)
@@ -748,7 +731,6 @@ def test_submit_json(mock_check_output, runner):
         assert data["name"] == "gridtk"
 
 
-@patch("gridtk.manager.JobManager.__del__", lambda self: None)
 @patch("subprocess.check_output")
 def test_wait_command(mock_check_output, runner):
     # Test wait with COMPLETED job (exit code 0)

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -740,12 +740,9 @@ def test_wait_command(mock_check_output, runner):
         _submit_job(
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
         )
-        mock_check_output.side_effect = _make_side_effect(
-            [
-                json.dumps(
-                    _jobs_sacct_dict([submit_job_id], "COMPLETED", "None", "node001")
-                ),
-            ]
+        # Use return_value so all calls (squeue, sacct, __del__) get valid data
+        mock_check_output.return_value = json.dumps(
+            _jobs_sacct_dict([submit_job_id], "COMPLETED", "None", "node001")
         )
         result = runner.invoke(cli, ["wait"])
         assert_click_runner_result(result)
@@ -758,11 +755,7 @@ def test_wait_command(mock_check_output, runner):
         _submit_job(
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
         )
-        mock_check_output.side_effect = _make_side_effect(
-            [
-                _failed_job_sacct_json(submit_job_id),
-            ]
-        )
+        mock_check_output.return_value = _failed_job_sacct_json(submit_job_id)
         result = runner.invoke(cli, ["wait"])
         assert_click_runner_result(result, exit_code=1)
         assert "Job 1: FAILED" in result.output

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -734,13 +734,16 @@ def test_submit_json(mock_check_output, runner):
 
 @patch("subprocess.check_output")
 def test_wait_command(mock_check_output, runner):
+    import gc
+
     # Test wait with COMPLETED job (exit code 0)
     with runner.isolated_filesystem():
         submit_job_id = 9876543
         _submit_job(
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
         )
-        # Use return_value so all calls (squeue, sacct, __del__) get valid data
+        # Force GC to run __del__ on submit's JobManager before changing mock
+        gc.collect()
         mock_check_output.return_value = json.dumps(
             _jobs_sacct_dict([submit_job_id], "COMPLETED", "None", "node001")
         )
@@ -755,6 +758,7 @@ def test_wait_command(mock_check_output, runner):
         _submit_job(
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
         )
+        gc.collect()
         mock_check_output.return_value = _failed_job_sacct_json(submit_job_id)
         result = runner.invoke(cli, ["wait"])
         assert_click_runner_result(result, exit_code=1)

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -696,12 +696,14 @@ Deleted job 5 with slurm id {third_grid_id + 10}
 
 @patch("subprocess.check_output")
 def test_list_json(mock_check_output, runner):
+    import gc
+
     with runner.isolated_filesystem():
         submit_job_id = 9876543
         _submit_job(
             runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
         )
-
+        gc.collect()
         mock_check_output.return_value = _pending_job_sacct_json(submit_job_id)
         result = runner.invoke(cli, ["list", "--json"])
         assert_click_runner_result(result)

--- a/tests/test_gridtk.py
+++ b/tests/test_gridtk.py
@@ -732,6 +732,42 @@ def test_submit_json(mock_check_output, runner):
         assert data["name"] == "gridtk"
 
 
+@patch("subprocess.check_output")
+def test_wait_command(mock_check_output, runner):
+    # Test wait with COMPLETED job (exit code 0)
+    with runner.isolated_filesystem():
+        submit_job_id = 9876543
+        _submit_job(
+            runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
+        )
+        mock_check_output.side_effect = _make_side_effect(
+            [
+                json.dumps(
+                    _jobs_sacct_dict([submit_job_id], "COMPLETED", "None", "node001")
+                ),
+            ]
+        )
+        result = runner.invoke(cli, ["wait"])
+        assert_click_runner_result(result)
+        assert "Job 1: COMPLETED" in result.output
+
+    # Test wait with FAILED job (exit code 1)
+    with runner.isolated_filesystem():
+        submit_job_id = 9876543
+        mock_check_output.side_effect = None
+        _submit_job(
+            runner=runner, mock_check_output=mock_check_output, job_id=submit_job_id
+        )
+        mock_check_output.side_effect = _make_side_effect(
+            [
+                _failed_job_sacct_json(submit_job_id),
+            ]
+        )
+        result = runner.invoke(cli, ["wait"])
+        assert_click_runner_result(result, exit_code=1)
+        assert "Job 1: FAILED" in result.output
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Summary
- Add `gridtk wait` command that polls jobs until all reach a terminal state
- Progress shows state breakdown: `Waiting for 5 job(s): 3 pending, 2 running`
- Exits with code 1 if any job ended in a failed state (FAILED, CANCELLED, TIMEOUT, etc.)
- Supports `--interval` option and all standard job filters
- Fix `JobManager.__del__` deleting DB due to SQLite session isolation — moved to explicit `cleanup_empty_database()` called after every CLI command
- Document `wait` command in README

### Examples
```
$ gridtk wait
Waiting for 1 job(s): 1 running (checking every 10s)
Job 1: COMPLETED (0)

$ echo $?
0

$ gridtk wait -j 1 --interval 30
Job 1: FAILED (1)

$ echo $?
1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview gridtk start -->
----
📚 Documentation preview 📚: https://gridtk--28.org.readthedocs.build/en/28/

<!-- readthedocs-preview gridtk end -->