### PR TITLE
docs: recommend uv for installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,29 @@ installation, submission, monitoring, and various commands provided by GridTK.
 Before diving into GridTK, ensure you have the following prerequisites:
 
 1. A working Slurm setup.
-2. [pipx](https://pipx.pypa.io/stable/) installed.
+2. [uv](https://docs.astral.sh/uv/) installed (recommended) or [pipx](https://pipx.pypa.io/stable/).
 3. GridTK installed (instructions provided below).
 
 ## Installation
 
-To install GridTK, open your terminal and run the following command:
+The recommended way to install GridTK is using `uv`:
+
+```bash
+$ uv tool install gridtk
+```
+
+Or run it directly without installing:
+
+```bash
+$ uvx gridtk --help
+```
+
+Alternatively, you can use `pipx`:
 
 ```bash
 $ pipx install gridtk
 ```
+
 It is **not recommended** to install GridTK using `pip install gridtk` in the
 same environment as your experiments. GridTK does not need to be installed in
 the same environment as your experiments and its dependencies may conflict with

--- a/src/gridtk/manager.py
+++ b/src/gridtk/manager.py
@@ -310,7 +310,7 @@ dependencies: {dependencies}"""
                 and len(self.list_jobs(update_jobs=False)) == 0
             ):
                 Path(self.database).unlink()
-                if self.logs_dir.exists() and len(os.listdir(self.logs_dir)) == 0:
+                if self.logs_dir.exists() and not any(self.logs_dir.iterdir()):
                     shutil.rmtree(self.logs_dir)
 
     def __del__(self):


### PR DESCRIPTION
## Summary
- Recommend `uv tool install` and `uvx` as primary installation methods, keep `pipx` as alternative
- Use `Path.iterdir()` instead of `os.listdir()` in `cleanup_empty_database` (from Yannick's review on #28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)