### PR TITLE
chore(docs): unshallow git history on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,9 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.9"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow
 
 python:
   install:


### PR DESCRIPTION
Builds of docs on [readthedocs.io](https://app.readthedocs.org/projects/gridtk/builds/31846804/) were failing because rtd shallow clones repos and `versioningit` requires the latest tags to determine the version.

Fetch the history after checking out from GitHub, before installing the package.

<!-- readthedocs-preview gridtk start -->
----
📚 Documentation preview 📚: https://gridtk--37.org.readthedocs.build/en/37/

<!-- readthedocs-preview gridtk end -->